### PR TITLE
fix: sessionauth parameter allows to run diagnostics against ODP environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 cov-int
 coverage
 hubot-symphony.iml
+certs

--- a/run-odp.sh
+++ b/run-odp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run hubot-symphony diagnostic against the Foundation Open Developer Platform
+
+# To run this script, you must install NodeJS and run npm install:
+# $ brew update
+# $ brew upgrade node
+# $ npm install
+
+npm run diagnostic -- --publicKey ./certs/publicCert.pem --privateKey ./certs/privateKey.pem --passphrase changeit --host foundation-dev.symphony.com --agenthost foundation-dev-api.symphony.com --kmhost foundation-dev-api.symphony.com --sessionhost foundation-dev-api.symphony.com

--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -97,8 +97,9 @@ class SymphonyAdapter extends Adapter
     publicKey = process.env.HUBOT_SYMPHONY_PUBLIC_KEY
     passprhase = process.env.HUBOT_SYMPHONY_PASSPHRASE
     keyManagerHost = process.env.HUBOT_SYMPHONY_KM_HOST ? host
+    sessionAuthHost = process.env.HUBOT_SYMPHONY_SESSIONAUTH_HOST ? host
     agentHost = process.env.HUBOT_SYMPHONY_AGENT_HOST ? host
-    @symphony = new Symphony({host: host, privateKey: privateKey, publicKey: publicKey, passphrase: passprhase, keyManagerHost: keyManagerHost, agentHost: agentHost})
+    @symphony = new Symphony({host: host, privateKey: privateKey, publicKey: publicKey, passphrase: passprhase, keyManagerHost: keyManagerHost, sessionAuthHost: sessionAuthHost, agentHost: agentHost})
     @symphony.whoAmI()
       .then (response) =>
         @robot.userId = response.userId

--- a/src/diagnostic.coffee
+++ b/src/diagnostic.coffee
@@ -40,6 +40,7 @@ symphony = new Symphony({
   passphrase: argv.passphrase,
   keyManagerHost: argv.kmhost ? argv.host,
   agentHost: argv.agenthost ? argv.host
+  sessionAuthHost: argv.sessionhost ? argv.host
 })
 
 logger.info 'Connection initiated, starting tests...'

--- a/src/symphony.coffee
+++ b/src/symphony.coffee
@@ -24,17 +24,20 @@ memoize = require 'memoizee'
 
 class Symphony
 
-  constructor: ({@host, @privateKey, @publicKey, @passphrase, @keyManagerHost, @agentHost}) ->
+  constructor: ({@host, @privateKey, @publicKey, @passphrase, @keyManagerHost, @sessionAuthHost, @agentHost}) ->
     @keyManagerHost = @keyManagerHost ? @host
+    @sessionAuthHost = @sessionAuthHost ? @host
     @agentHost = @agentHost ? @host
     logger.info "Connecting to #{@host}"
     if @keyManagerHost isnt @host
       logger.info "Using separate KeyManager #{@keyManagerHost}"
+    if @sessionAuthHost isnt @host
+      logger.info "Using separate SessionAuth #{@sessionAuthHost}"
     if @agentHost isnt @host
       logger.info "Using separate Agent #{@agentHost}"
     # refresh tokens on a weekly basis
     weeklyRefresh = memoize @_httpPost, {maxAge: 604800000, length: 2}
-    @sessionAuth = => weeklyRefresh @host, '/sessionauth/v1/authenticate'
+    @sessionAuth = => weeklyRefresh @sessionAuthHost, '/sessionauth/v1/authenticate'
     @keyAuth = => weeklyRefresh @keyManagerHost, '/keyauth/v1/authenticate'
     Q.all([@sessionAuth(), @keyAuth()]).then (values) ->
       logger.info "Initialising with sessionToken: #{values[0].token} and keyManagerToken: #{values[1].token}"


### PR DESCRIPTION
This way testing against https://foundation-dev.symphony.com works as expected.

This is a preliminary step to enable the hubot-symphony diagnostic to run continuously from Travis CI.

/CC @jonfreedman @mistryvinay